### PR TITLE
fix: ensure checkbox field uses boolean

### DIFF
--- a/src/components/users/user-invitation-form.tsx
+++ b/src/components/users/user-invitation-form.tsx
@@ -199,8 +199,10 @@ export function UserInvitationForm({
                 render={({ field }) => (
                   <div className="flex flex-row items-start space-x-3 space-y-0">
                     <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
+                      checked={field.value ?? false}
+                      onCheckedChange={checked =>
+                        field.onChange(checked === true)
+                      }
                     />
                     <div className="space-y-1 leading-none">
                       <Label>Internal Staff Member</Label>


### PR DESCRIPTION
## Summary
- fix `Checkbox` for internal staff member so `checked` is always boolean

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'active' does not exist on type 'UserWithDivisions', etc.)*
- `npm run build` *(fails: Failed to fetch font `Inter`.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d06467308333847d4c6955798404